### PR TITLE
Fixes a bug.

### DIFF
--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -96,11 +96,11 @@ class MessageParser {
     {
         $content = strtolower($message->content);
         // Grab the first 4 chars for our trigger
-        $trigger = substr($content, 0, 4);
+        $trigger = substr($content, 0, 5);
         // Grab everything after the first 5 chars
         $query = substr($content, 5);
 
-        if($trigger === "docs")
+        if($trigger === "docs ")
         {
             if(in_array($query, $this->docs)){
 


### PR DESCRIPTION
Currently the parser only executes a command if the first 4 letters is `docs` and everything after the 6th message is a match on one of the `$docs` values. Allowing the 5th character to be anything. This causes `docsaurls` (might be a soon-to-be-found dinosaur) for example to trigger the bot. My elegant solution fixes this, so the first 5 characters has to be `docs `.