### PR TITLE
Defaults non existing versions to default docs

### DIFF
--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -92,6 +92,13 @@ class MessageParser {
                 "vite",
             ];
 
+    protected $versions = [
+                "9.x",
+                "8.x",
+                "7.x",
+                "6.x",
+    ];
+
     public function __invoke($message)
     {
         $content = strtolower($message->content);
@@ -103,12 +110,12 @@ class MessageParser {
         $query = substr($content, 5);
 
         // Check if version is available in command
-        $pattern = '/\b([6-9]\.x)\b/'; // only match 6.x to 9.x
+        $pattern = '/\b([0-9]+\.([0-9]|[x])+)\b/';
         preg_match($pattern, $query, $matches);
 
         if ($matches) {
             $query = preg_replace($pattern, '', $query);
-            $version = $matches[0];
+            $version = in_array($matches[0], $this->versions) ? $matches[0] : null;
         }
 
         $query = trim($query);

--- a/tests/MessageParserTest.php
+++ b/tests/MessageParserTest.php
@@ -127,7 +127,9 @@ class messageParserTest extends TestCase
             ["docs vite", "<https://laravel.com/docs/vite>"],
             ["docs 9.x csrf", "<https://laravel.com/docs/9.x/csrf>"],
             ["docs 8.x csrf", "<https://laravel.com/docs/8.x/csrf>"],
-            ["docs 10.x csrf", false],
+            ["docs 10.x csrf", "<https://laravel.com/docs/csrf>"],
+            ["docs 5.4 csrf", "<https://laravel.com/docs/csrf>"],
+            ["docs csrf 5.4", "<https://laravel.com/docs/csrf>"],
             ["docs csrf 9.x",  "<https://laravel.com/docs/9.x/csrf>"],
         ];
     }


### PR DESCRIPTION
Still parses wrong version numbers such as:

`docs 11.1 csrf`
`docs 5.4 csrf`

Defaults to the non-versionized URL.